### PR TITLE
Fix sporadic crashes with MSIM devices and inactive SIMs

### DIFF
--- a/src/com/android/server/telecom/PhoneAccountRegistrar.java
+++ b/src/com/android/server/telecom/PhoneAccountRegistrar.java
@@ -236,6 +236,10 @@ public final class PhoneAccountRegistrar {
         for (int i = 0; i < mState.accounts.size(); i++) {
             String id = mState.accounts.get(i).getAccountHandle().getId();
 
+            if (id == null || id.equals("null") || TextUtils.isEmpty(id)) {
+                continue;
+            }
+
             // emergency account present return it
             if (id.equals("E")) {
                 Log.i(this, "getUserSelVoicePhoneAccount, emergency account ");


### PR DESCRIPTION
An MSIM device with a single inactive SIM (PIN locked, for instance)
can and frequently will get into a situation where it tries to set
ip invalid IDs (none have been assigned) as the "default" voice sub

Fixes CYNGNOS-2711

Change-Id: I7fcc1f42e5e74886192bbb5f8a74f3a69473e761