### PR TITLE
Telecom: Break qti-telephony-framework dependency

### DIFF
--- a/src/com/android/server/telecom/Call.java
+++ b/src/com/android/server/telecom/Call.java
@@ -758,7 +758,7 @@ public class Call implements CreateConnectionResponse {
             // call, it will remain so for the rest of it's lifetime.
             if (!mIsEmergencyCall) {
                 mIsEmergencyCall = mHandle != null && TelephonyUtil.isLocalEmergencyNumber(
-                        mHandle.getSchemeSpecificPart());
+                        mContext, mHandle.getSchemeSpecificPart());
             }
             startCallerInfoLookup();
             for (Listener l : mListeners) {

--- a/src/com/android/server/telecom/NewOutgoingCallIntentBroadcaster.java
+++ b/src/com/android/server/telecom/NewOutgoingCallIntentBroadcaster.java
@@ -119,7 +119,8 @@ public class NewOutgoingCallIntentBroadcaster {
                 if (resultNumber == null) {
                     Log.v(this, "Call cancelled (null number), returning...");
                     endEarly = true;
-                } else if (TelephonyUtil.isPotentialLocalEmergencyNumber(resultNumber)) {
+                } else if (TelephonyUtil.isPotentialLocalEmergencyNumber(
+                        mPhoneNumberUtilsAdapter, mContext, resultNumber)) {
                     Log.w(this, "Cannot modify outgoing call to emergency number %s.",
                             resultNumber);
                     endEarly = true;
@@ -438,7 +439,8 @@ public class NewOutgoingCallIntentBroadcaster {
      */
     private boolean isPotentialEmergencyNumber(String number) {
         Log.v(this, "Checking restrictions for number : %s", Log.pii(number));
-        return (number != null) && TelephonyUtil.isPotentialLocalEmergencyNumber(number);
+        return (number != null) && TelephonyUtil.isPotentialLocalEmergencyNumber(
+                                                    mPhoneNumberUtilsAdapter, mContext, number);
     }
 
     /**

--- a/src/com/android/server/telecom/TelephonyUtil.java
+++ b/src/com/android/server/telecom/TelephonyUtil.java
@@ -69,34 +69,37 @@ public final class TelephonyUtil {
     }
 
     public static boolean shouldProcessAsEmergency(Context context, Uri handle) {
-        return handle != null && isLocalEmergencyNumber(handle.getSchemeSpecificPart());
+        return handle != null && isLocalEmergencyNumber(context, handle.getSchemeSpecificPart());
     }
 
-    public static boolean isLocalEmergencyNumber(String address) {
+    public static boolean isLocalEmergencyNumber(Context context, String address) {
         IExtTelephony mIExtTelephony =
             IExtTelephony.Stub.asInterface(ServiceManager.getService("extphone"));
-        boolean result = false;
-        try {
-            result = mIExtTelephony.isLocalEmergencyNumber(address);
-        }catch (RemoteException ex) {
-            Log.e(LOG_TAG, ex, "RemoteException");
-        } catch (NullPointerException ex) {
-            Log.e(LOG_TAG, ex, "NullPointerException");
+        if (mIExtTelephony == null) {
+            return PhoneNumberUtils.isLocalEmergencyNumber(context, address);
         }
-        return result;
+
+        try {
+            return mIExtTelephony.isLocalEmergencyNumber(address);
+        } catch (RemoteException ex) {
+            Log.e(LOG_TAG, ex, "RemoteException");
+            return PhoneNumberUtils.isLocalEmergencyNumber(context, address);
+        }
     }
 
-    public static boolean isPotentialLocalEmergencyNumber(String address) {
+    public static boolean isPotentialLocalEmergencyNumber(
+            PhoneNumberUtilsAdapter adapter, Context context, String address) {
         IExtTelephony mIExtTelephony =
             IExtTelephony.Stub.asInterface(ServiceManager.getService("extphone"));
-        boolean result = false;
-        try {
-            result = mIExtTelephony.isPotentialLocalEmergencyNumber(address);
-        }catch (RemoteException ex) {
-            Log.e(LOG_TAG, ex, "RemoteException");
-        } catch (NullPointerException ex) {
-            Log.e(LOG_TAG, ex, "NullPointerException");
+        if (mIExtTelephony == null) {
+            return adapter.isPotentialLocalEmergencyNumber(context, address);
         }
-        return result;
+
+        try {
+            return mIExtTelephony.isPotentialLocalEmergencyNumber(address);
+        } catch (RemoteException ex) {
+            Log.e(LOG_TAG, ex, "RemoteException");
+            return adapter.isPotentialLocalEmergencyNumber(context, address);
+        }
     }
 }


### PR DESCRIPTION
  Not all devices have qti-telephony-framework,
  so fall back to AOSP's methods if needed.

Change-Id: Ib6de738a292203be3d125ab34d6c8682a32007d5