### PR TITLE
Telecom: Ues proper sub IDs

### DIFF
--- a/src/com/android/server/telecom/BluetoothPhoneServiceImpl.java
+++ b/src/com/android/server/telecom/BluetoothPhoneServiceImpl.java
@@ -46,7 +46,6 @@ import android.telecom.TelecomManager;
 import com.android.internal.annotations.VisibleForTesting;
 import com.android.server.telecom.CallsManager.CallsManagerListener;
 
-import java.lang.NumberFormatException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -189,14 +188,7 @@ public class BluetoothPhoneServiceImpl {
                     if (account != null) {
                         PhoneAccountHandle ph = account.getAccountHandle();
                         if (ph != null) {
-                            String subId = ph.getId();
-                            int sub;
-                            try {
-                                sub = Integer.parseInt(subId);
-                            } catch (NumberFormatException e){
-                                Log.w(this, " NumberFormatException " + e);
-                                sub = SubscriptionManager.getDefaultVoiceSubscriptionId();
-                            }
+                            int sub = mPhoneAccountRegistrar.getSubscriptionIdForPhoneAccount(ph);
                             label = TelephonyManager.from(mContext)
                                     .getNetworkOperatorName(sub);
                         } else {
@@ -1113,23 +1105,13 @@ public class BluetoothPhoneServiceImpl {
         if (mBluetoothDsda != null) {
             Log.d(TAG, "Get the Sub on which call state change happened");
             if (call.getTargetPhoneAccount() != null) {
-                String sub = call.getTargetPhoneAccount().getId();
-                subscription = SubscriptionManager.getDefaultVoiceSubscriptionId();
-                try {
-                    subscription = Integer.parseInt(sub);
-                } catch (NumberFormatException e) {
-                    Log.w(this, " NumberFormatException " + e);
-                }
+                PhoneAccountHandle ph = call.getTargetPhoneAccount();
+                int sub = mPhoneAccountRegistrar.getSubscriptionIdForPhoneAccount(ph);
             } else if (call.isConference()) {
                 for (Call childCall : call.getChildCalls()) {
                     if (childCall.getTargetPhoneAccount() != null) {
-                        String sub = childCall.getTargetPhoneAccount().getId();
-                        subscription = SubscriptionManager.getDefaultVoiceSubscriptionId();
-                        try {
-                            subscription = Integer.parseInt(sub);
-                        } catch (NumberFormatException e) {
-                            Log.w(this, " NumberFormatException " + e);
-                        }
+                        PhoneAccountHandle ph = call.getTargetPhoneAccount();
+                        int sub = mPhoneAccountRegistrar.getSubscriptionIdForPhoneAccount(ph);
                     } else {
                         Log.w(this, "PhoneAccountHandle is NULL for childCall: " + childCall);
                     }
@@ -1196,23 +1178,14 @@ public class BluetoothPhoneServiceImpl {
 
         if (activeCall != null && activeCall.isConference()) {
             if (activeCall.getTargetPhoneAccount() != null) {
+                PhoneAccountHandle ph = activeCall.getTargetPhoneAccount();
+                activeCallSub = mPhoneAccountRegistrar.getSubscriptionIdForPhoneAccount(ph);
                 String sub = activeCall.getTargetPhoneAccount().getId();
-                activeCallSub = SubscriptionManager.getDefaultVoiceSubscriptionId();
-                try {
-                    activeCallSub = Integer.parseInt(sub);
-                } catch (NumberFormatException e) {
-                    Log.w(this, " NumberFormatException " + e);
-                }
             } else {
                 for (Call childCall : activeCall.getChildCalls()) {
                     if (childCall.getTargetPhoneAccount() != null) {
-                        String sub = childCall.getTargetPhoneAccount().getId();
-                        activeCallSub = SubscriptionManager.getDefaultVoiceSubscriptionId();
-                        try {
-                            activeCallSub = Integer.parseInt(sub);
-                        } catch (NumberFormatException e) {
-                            Log.w(this, " NumberFormatException " + e);
-                        }
+                        PhoneAccountHandle ph = activeCall.getTargetPhoneAccount();
+                        activeCallSub = mPhoneAccountRegistrar.getSubscriptionIdForPhoneAccount(ph);
                     } else {
                         Log.w(this, "PhoneAccountHandle is NULL for childCall: " + childCall);
                     }

--- a/src/com/android/server/telecom/PhoneAccountRegistrar.java
+++ b/src/com/android/server/telecom/PhoneAccountRegistrar.java
@@ -924,23 +924,10 @@ public class PhoneAccountRegistrar {
         Collections.sort(handles, new Comparator<PhoneAccountHandle>() {
             public int compare(PhoneAccountHandle accountHandle1
                         , PhoneAccountHandle accountHandle2) {
-                TelephonyManager tm = (TelephonyManager) mContext
-                        .getSystemService(Context.TELEPHONY_SERVICE);
-                int max = tm.getPhoneCount();
-                int phoneId1 = max;
-                int phoneId2 = max;
-                try {
-                    phoneId1 = SubscriptionManager
-                            .getPhoneId(Integer.parseInt(accountHandle1.getId()));
-                } catch (NumberFormatException e) {
-                    Log.e(this, e, "Could not parse subId1 " + accountHandle1.getId());
-                }
-                try {
-                    phoneId2 = SubscriptionManager
-                            .getPhoneId(Integer.parseInt(accountHandle2.getId()));
-                } catch (NumberFormatException e) {
-                    Log.e(this, e, "Could not parse subId2 " + accountHandle2.getId());
-                }
+                int subId1 = getSubscriptionIdForPhoneAccount(accountHandle1);
+                int subId2 = getSubscriptionIdForPhoneAccount(accountHandle2);
+                int phoneId1 = SubscriptionManager.getPhoneId(subId1);
+                int phoneId2 = SubscriptionManager.getPhoneId(subId2);
                 return (phoneId1 < phoneId2 ? -1 : (phoneId1 == phoneId2 ? 0 : 1));
             }
         });


### PR DESCRIPTION
It is assumed that the ID of every PhoneAccountHandle is the string
equivalent of an int, however, the ID can also includes hex chars or,
in case of the emergency account handle, it's just "E". This causes
issues when we try to get the sub ID using Integer.parseInt(),
so don't do it.

Change-Id: If82c8146d01dba03cc3323aef9a4df84dc1f4bfd