### PR TITLE
telecom: Ensure that we always update bluetooth in dsda case

### DIFF
--- a/src/com/android/server/telecom/BluetoothPhoneServiceImpl.java
+++ b/src/com/android/server/telecom/BluetoothPhoneServiceImpl.java
@@ -268,13 +268,11 @@ public class BluetoothPhoneServiceImpl {
                 long token = Binder.clearCallingIdentity();
                 try {
                     Log.i(TAG, "queryPhoneState");
-                    if (isDsdaEnabled()) {
-                        if (mBluetoothDsda != null) {
-                            try {
-                                mBluetoothDsda.processQueryPhoneState();
-                            } catch (RemoteException e) {
-                                Log.i(TAG, "DSDA Service not found exception " + e);
-                            }
+                    if (isDsdaEnabled() && (mBluetoothDsda != null)) {
+                        try {
+                            mBluetoothDsda.processQueryPhoneState();
+                        } catch (RemoteException e) {
+                            Log.i(TAG, "DSDA Service not found exception " + e);
                         }
                     } else {
                         updateHeadsetWithCallState(true /* force */, null);
@@ -966,7 +964,7 @@ public class BluetoothPhoneServiceImpl {
      * @ param call is specified call for which Headset is to be updated.
      */
     private void updateHeadsetWithCallState(boolean force, Call call) {
-        if (isDsdaEnabled() && (call != null)) {
+        if (isDsdaEnabled() && (call != null) && (mBluetoothDsda != null)) {
             Log.d(TAG, "DSDA call operation, handle it separately");
             updateDsdaServiceWithCallState(call);
         } else {


### PR DESCRIPTION
If you do not send the bluetooth headset service phone state
information then headset calls (SCO) will not work.

The reason that the state must be passed along for the calls
to work is that (in 6.0) there is now a check against the
current call state before allow SCO connections from the
headset (in packages/apps/Bluetooth):

commit 1f7879f020043ee2f255ec3c04804b9b9c2ff869
Author: Mallikarjuna GB <gbmalli@codeaurora.org>
Date:   Thu Jun 4 18:07:04 2015 +0530

    Do not accept SCO without any active listener.

However, in the DSDA case we do not send any phone state updates
if there is no BluetoothDsdaService then we neither send updates
to it nor to the HeadsetService.

Fix the couple of cases where it does not handle this correctly
which fixes bluetooth (SCO) calls on DSDA devices.

Change-Id: I23c9c958dc4edccaba510b327e35999609bdd186
(cherry picked from commit 9aaa63710a972ff74a62a31d9d3e92f7eef38355)