### PR TITLE
Telecomm: Add missing CMSDK dependencies in tests

### DIFF
--- a/tests/Android.mk
+++ b/tests/Android.mk
@@ -23,7 +23,8 @@ LOCAL_STATIC_JAVA_LIBRARIES := \
         guava \
         mockito-target \
         platform-test-annotations \
-        ims-ext-common
+        ims-ext-common \
+        org.cyanogenmod.platform.internal
 
 LOCAL_SRC_FILES := \
         $(call all-java-files-under, src) \


### PR DESCRIPTION
The tests package has missing dependencies on the CMSDK,
resulting in compilation errors.

Add org.cyanogenmod.platform.internal to
LOCAL_STATIC_JAVA_LIBRARIES to fix the errors:

ERROR: /packages/services/Telecomm/src/com/android/server/telecom/Ringer.java:30: The import cyanogenmod cannot be resolved
ERROR: /packages/services/Telecomm/src/com/android/server/telecom/Ringer.java:131: CMSettings cannot be resolved
...
ERROR: /packages/services/Telecomm/src/com/android/server/telecom/ui/MissedCallNotifierImpl.java:84: The import cyanogenmod cannot be resolved
ERROR: /packages/services/Telecomm/src/com/android/server/telecom/ui/MissedCallNotifierImpl.java:578: CMSettings cannot be resolved

Change-Id: Ic5f190300fce44fec6be871ccfce53d57fcf86f5