### PR TITLE
Telecomm: Fix error due to protected broadcast

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -21,6 +21,7 @@
         android:sharedUserId="android.uid.system">
 
     <protected-broadcast android:name="android.intent.action.SHOW_MISSED_CALLS_NOTIFICATION" />
+    <protected-broadcast android:name="codeaurora.intent.action.DEFAULT_PHONE_ACCOUNT_CHANGED" />
 
     <!-- Prevents the activity manager from delaying any activity-start
          requests by this package, including requests immediately after


### PR DESCRIPTION
* Add protected broadcast to manifest

The broadcast is sent here:
https://github.com/LineageOS/android_packages_services_Telecomm/blob/cm-14.1/src/com/android/server/telecom/PhoneAccountRegistrar.java#L751

As stated in ActivityManagerService:
  The vast majority of broadcasts sent from system internals
  should be protected to avoid security holes

Change-Id: I400cb747e898e7abf0b71f726ced58794c49c8f6